### PR TITLE
Use maintained Docker baseimage

### DIFF
--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,8 +1,12 @@
-FROM julianbei/alpine-opencv-microimage:p3-3.1
+FROM python:3.10-slim
 
-RUN apk add --update openssl-dev jpeg-dev git
-RUN apk add --no-cache libimagequant@edge pngquant@edgunity
-RUN apk add --no-cache libjpeg-turbo-utils
-RUN apk del cmake curl-dev
-RUN apk add --update curl-dev libffi-dev cmake
-RUN pip install pipenv
+RUN apt-get update -y && apt-get install -y \
+    python3-dev libcurl4-openssl-dev libgnutls28-dev python3-all-dev \
+    libboost-python-dev make zlib1g-dev gcc libssl-dev \
+    && apt-get clean
+RUN apt-get update -y && apt-get install --reinstall -y \
+    build-essential \
+    && apt-get clean
+
+RUN pip install --upgrade pip
+


### PR DESCRIPTION
With the intention of letting test pass so we can work on https://github.com/thumbor-community/aws/pull/147

This base image only (roughly) contains up to date dependencies needed to run test for tc_aws on CircleCI (and locally).

@Bladrak If the CircleCI + Docker Hub setup is still working we should be able to use this together with: https://github.com/thumbor-community/aws/pull/153